### PR TITLE
update nvm source command to fix not found error

### DIFF
--- a/config-miner-neon.sh
+++ b/config-miner-neon.sh
@@ -18,7 +18,8 @@ sudo apt-get install -y build-essential cmake libssl-dev pkg-config jq
 
 # install nvm
 wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-source .bashrc
+# shellcheck source=src/.bashrc
+source $HOME/.bashrc
 
 # install node via nvm
 nvm install node


### PR DESCRIPTION
The first time through the script was unable to find the `nvm` command, but after running `source .bashrc`, it worked. The script should be doing this as part of the install, so I changed up the formatting a bit to see if that helps.