### PR TITLE
add warning to neon script before run

### DIFF
--- a/config-miner-neon.sh
+++ b/config-miner-neon.sh
@@ -13,6 +13,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+# Add warning to beginning since this is from an older phase of testnet.
+printf '\n\e[1;31m%-6s\e[m\n' "NOTE: This script was created for a previous phase of the Blockstack Testnet (Neon), and is stored here for historic purposes."
+printf '\e[1;31m%-6s\e[m\n' "Please review the readme for the most updated version."
+read -rsn1 -p"Press any key to continue . . ."
+echo
+
 # install prerequisites
 sudo apt-get install -y build-essential cmake libssl-dev pkg-config jq
 


### PR DESCRIPTION
A quick note and pause to designate the neon script is there for historic purposes, and will not work as intended.