### PR TITLE
Add debug mode and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The specifications I used for my Ubuntu Server virtual machine are listed and pi
 To run the script, simply use the command below! It will download the file from this repository and run it using `bash`.
 
 ```
-curl -o- https://raw.githubusercontent.com/AbsorbingChaos/bks-setup-miner/master/config-miner-argon.sh | bash
+curl -sS -o- https://raw.githubusercontent.com/AbsorbingChaos/bks-setup-miner/master/config-miner-argon.sh | bash
 ```
 
 To see a video of the script in action, check out [this YouTube link!](https://youtu.be/rOs8ZqCt_xM)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,78 @@
 
 [![Testnet Phase Argon Badge](https://img.shields.io/static/v1?label=Stacks%202.0%20Testnet%20Phase&message=%232%20Argon&color=9cf&style=for-the-badge)](https://forum.blockstack.org/t/stacks-2-0-testnet-coming-soon/10510)
 
-This repository contains a handy script that will help you run a Miner Node on the [Blockstack Stacks 2.0 Testnet](https://testnet.blockstack.org/)!
+This repository contains a simple script that will help you run a Miner Node on the [Stacks 2.0 Testnet](https://testnet.blockstack.org/).
 
 ## Requirements
 
-This script is designed for and tested on [Ubuntu Server 20.04 LTS](https://ubuntu.com/server).
+This script is designed for and tested with [Ubuntu Server 20.04 LTS](https://ubuntu.com/server).
 
 In theory, it should work for any Ubuntu-based installation but [YMMV](https://dictionary.cambridge.org/us/dictionary/english/ymmv).
+
+If you run into an error, please [file an issue](https://github.com/AbsorbingChaos/bks-setup-miner/issues) with more information.
+
+## Using the Script
+
+**To run the script**, simply use the command below.
+
+```
+curl -sS -o- https://raw.githubusercontent.com/AbsorbingChaos/bks-setup-miner/master/config-miner-argon.sh | bash
+```
+
+It will download the file from this repository and run it via `bash`.
+
+To stop the script or the miner (once it's running), press `ctrl+c`.
+
+The script can be run multiple times, and will complete the following tasks:
+
+1. Install or update operating system prerequisites
+    - `build-essential cmake libssl-dev pkg-config jq git bc`
+2. Detect or install node version manager (nvm)
+3. Detect or install Node.js (via nvm)
+4. Detect or install Rust (via rustup.rs)
+5. Download or update the stacks-blockchain repository (via git)
+6. Detect or create the keychain file (via blockstack-cli make_keychain)
+7. Detect or request test BTC balance (via keychain file and [faucet](https://testnet.blockstack.org/faucet))
+8. Detect or download miner configuration file (via GitHub)
+    - If downloaded, automatically inserts the private key (via keychain file)
+9. Check test BTC balance before starting the miner process
+10. Start the miner and try to win the sortitions!
+
+This link will allow you to [manually view or download the script](https://github.com/AbsorbingChaos/bks-setup-miner/blob/master/config-miner-argon.sh), if you are into that kind of thing.
+
+## Using the Script: Debug Mode
+
+**To run the script in debug mode**, there are a few extra steps involved.
+
+First, download the script:
+
+```
+curl -sS -O https://raw.githubusercontent.com/AbsorbingChaos/bks-setup-miner/master/config-miner-argon.sh
+```
+
+Second, run the script with the `debug` option:
+
+```
+bash config-miner-argon.sh debug
+```
+
+In addition to the tasks listed above, this will:
+
+1. Delete and download a new copy of the stacks-blockchain repository (via git)
+2. Record the output of `cargo start` using the `script` command, to a file named `bks-miner-YYYYMMDD-HHMMSS.txt`
+3. Run `cargo start` with the environment variables `BLOCKSTACK_DEBUG=1` and `RUST_BACKTRACE=full`
+
+This file contains a copy of all the terminal output seen on the screen, and is saved if the miner crashes or when the miner is stopped with `ctrl+c`.
+
+## Examples / More Info
+
+### Live Demonstration
+
+To view a live demonstration of the setup for Virtualbox, Ubuntu Server, and usage of the script, check out the video below!
+
+- [Stacks 2.0 Miner Script Demo](https://www.youtube.com/watch?v=Lz1VSlIbMiE)
+
+### Virtual Machine Setup
 
 Before running the script, I recommend setting up a virtual machine using [Virtualbox](https://www.virtualbox.org/).
 
@@ -24,32 +89,6 @@ The specifications I used for my Ubuntu Server virtual machine are listed and pi
 - Network: Bridged Adapter
 
 ![Screenshot from 2020-06-02 09-21-11](https://user-images.githubusercontent.com/9038904/83544659-1b291580-a4b3-11ea-8ec9-ffb2cf16d52c.png)
-
-## Using the Script
-
-To run the script, simply use the command below! It will download the file from this repository and run it using `bash`.
-
-```
-curl -sS -o- https://raw.githubusercontent.com/AbsorbingChaos/bks-setup-miner/master/config-miner-argon.sh | bash
-```
-
-To see a video of the script in action, check out [this YouTube link!](https://youtu.be/rOs8ZqCt_xM)
-
-The script can be run multiple times, and will check for and complete the following tasks:
-
-1. Install or update operating system prerequisites `build-essential cmake libssl-dev pkg-config jq git`
-2. Detect or install node version manager (nvm)
-3. Detect or install Node.js (via nvm)
-4. Detect or install Rust (via rustup.rs)
-5. Download or update the stacks-blockchain repository (via git)
-6. Detect or create the keychain file (via blockstack-cli make_keychain)
-7. Detect or request tBTC balance (via keychain file and [faucet](https://testnet.blockstack.org/faucet))
-8. Detect or download miner configuration file (via GitHub)
-    - If the miner configuration file is downloaded, automatically inserts the private key (via keychain file)
-9. Check tBTC balance before starting the miner process
-10. Start the miner and try to win the sortitions!
-
-This link will allow you to [manually view or download the script](https://github.com/AbsorbingChaos/bks-setup-miner/blob/master/config-miner-argon.sh), if you are into that kind of thing.
 
 ## Final Word
 

--- a/config-miner-argon.sh
+++ b/config-miner-argon.sh
@@ -30,7 +30,7 @@ if [ "$__action" == "debug" ];
     printf '\n\e[1;33m%-6s\e[m' "SCRIPT: DEBUG MODE ENABLED."
     printf '\n\e[1;33m%-6s\e[m' "DEBUG: script output will be recorded to file,"
     printf '\n\e[1;33m%-6s\e[m' "DEBUG: cargo will be launched with env vars:"
-    printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: BLOCKSTACK_DEBUG=1 and RUST_BACKTRACE=full"
+    printf '\n\e[1;33m%-6s\e[m' "DEBUG: BLOCKSTACK_DEBUG=1 and RUST_BACKTRACE=full"
 fi
 
 ###################

--- a/config-miner-argon.sh
+++ b/config-miner-argon.sh
@@ -27,9 +27,9 @@ __debug=false
 if [ "$__action" == "debug" ];
   then
     __debug=true
-    printf '\n\e[1;33m%-6s\e[m\n' "SCRIPT: DEBUG MODE ENABLED."
-    printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: script output will be recorded to file,"
-    printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: cargo will be launched with env vars:"
+    printf '\n\e[1;33m%-6s\e[m' "SCRIPT: DEBUG MODE ENABLED."
+    printf '\n\e[1;33m%-6s\e[m' "DEBUG: script output will be recorded to file,"
+    printf '\n\e[1;33m%-6s\e[m' "DEBUG: cargo will be launched with env vars:"
     printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: BLOCKSTACK_DEBUG=1 and RUST_BACKTRACE=full"
 fi
 

--- a/config-miner-argon.sh
+++ b/config-miner-argon.sh
@@ -17,6 +17,22 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+# Setup initial variables allowing for different
+# actions in the future, if needed.
+__action="${1:-}"
+__debug=false
+
+# Check if debug options requested and set var
+# and notify user of extra options.
+if [ "$__action" == "debug" ];
+  then
+    __debug=true
+    printf '\n\e[1;33m%-6s\e[m\n' "SCRIPT: DEBUG MODE ENABLED."
+    printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: script output will be recorded to file,"
+    printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: cargo will be launched with env vars:"
+    printf '\n\e[1;33m%-6s\e[m\n' "DEBUG: BLOCKSTACK_DEBUG=1 and RUST_BACKTRACE=full"
+fi
+
 ###################
 # PRE-REQUISUITES #
 ###################
@@ -70,11 +86,23 @@ source $HOME/.cargo/env
 # stacks-blockchain repository
 # https://github.com/blockstack/stacks-blockchain
 if [ -d "$HOME/stacks-blockchain" ]; then
-  printf '\e[1;32m%-6s\e[m\n' "SCRIPT: stacks-blockchain directory detected. updating via git."
-  # switch to directory
-  cd $HOME/stacks-blockchain
-  # update from github repo
-  git pull
+  if [ "$__debug" == true ];
+    then
+      # DEBUG: if true, we want to remove it and download
+      # a fresh copy of the stacks-blockchain repository
+      printf '\e[1;32m%-6s\e[m\n' "DEBUG: stacks-blockchain directory detected. removing."
+      # remove stacks-blockchain local directory
+      rm -rf $HOME/stacks-blockchain
+      printf '\e[1;32m%-6s\e[m\n' "DEBUG: cloning stacks-blockchain directory via git."
+      # clone stacks-blockchain repo
+      git clone https://github.com/blockstack/stacks-blockchain.git $HOME/stacks-blockchain
+  else
+    printf '\e[1;32m%-6s\e[m\n' "SCRIPT: stacks-blockchain directory detected. updating via git."
+    # switch to directory
+    cd $HOME/stacks-blockchain
+    # update from github repo
+    git pull
+  fi
 else
   printf '\e[1;31m%-6s\e[m\n' "SCRIPT: stacks-blockchain directory not found, cloning via git."
   # clone stacks-blockchain repo

--- a/config-miner-argon.sh
+++ b/config-miner-argon.sh
@@ -90,10 +90,10 @@ if [ -d "$HOME/stacks-blockchain" ]; then
     then
       # DEBUG: if true, we want to remove it and download
       # a fresh copy of the stacks-blockchain repository
-      printf '\e[1;32m%-6s\e[m\n' "DEBUG: stacks-blockchain directory detected. removing."
+      printf '\e[1;33m%-6s\e[m\n' "DEBUG: stacks-blockchain directory detected. removing."
       # remove stacks-blockchain local directory
       rm -rf $HOME/stacks-blockchain
-      printf '\e[1;32m%-6s\e[m\n' "DEBUG: cloning stacks-blockchain directory via git."
+      printf '\e[1;33m%-6s\e[m\n' "DEBUG: cloning stacks-blockchain directory via git."
       # clone stacks-blockchain repo
       git clone https://github.com/blockstack/stacks-blockchain.git $HOME/stacks-blockchain
   else
@@ -157,8 +157,21 @@ until [[ "$btc_balance" -gt "0" ]]; do
   btc_balance=$(echo ${btc_balance%.*})
 done
 
-printf '\e[1;32m%-6s\e[m\n\n' "SCRIPT: All checks passed, starting Blockstack Argon miner!"
+printf '\e[1;32m%-6s\e[m\n\n' "SCRIPT: All checks passed, starting miner with cargo."
 # change working directory to stacks-blockchain folder
 cd $HOME/stacks-blockchain
-# start the miner!
-cargo testnet start --config ./testnet/stacks-node/conf/argon-miner-conf.toml
+
+if [ "$__debug" == true ];
+  then
+    # DEBUG: if true, record terminal output to a file
+    # and start miner using environment vars for debugging
+    __stamp=$(date +"%Y%m%d-%H%M%S")
+    __file="bks-miner-$__stamp.txt"
+    printf '\e[1;33m%-6s\e[m\n' "DEBUG: terminal output saved to:"
+    printf '\e[1;33m%-6s\e[m\n' "DEBUG: $(pwd)/$__file"
+    script $__file
+    BLOCKSTACK_DEBUG=1 RUST_BACKTRACE=full cargo testnet start --config ./testnet/stacks-node/conf/argon-miner-conf.toml
+  else
+    # start the miner!
+    cargo testnet start --config ./testnet/stacks-node/conf/argon-miner-conf.toml
+fi

--- a/config-miner-argon.sh
+++ b/config-miner-argon.sh
@@ -169,8 +169,7 @@ if [ "$__debug" == true ];
     __file="bks-miner-$__stamp.txt"
     printf '\e[1;33m%-6s\e[m\n' "DEBUG: terminal output saved to:"
     printf '\e[1;33m%-6s\e[m\n' "DEBUG: $(pwd)/$__file"
-    script $__file
-    BLOCKSTACK_DEBUG=1 RUST_BACKTRACE=full cargo testnet start --config ./testnet/stacks-node/conf/argon-miner-conf.toml
+    script -c "BLOCKSTACK_DEBUG=1 RUST_BACKTRACE=full cargo testnet start --config ./testnet/stacks-node/conf/argon-miner-conf.toml" $__file
   else
     # start the miner!
     cargo testnet start --config ./testnet/stacks-node/conf/argon-miner-conf.toml


### PR DESCRIPTION
This PR introduces a few changes and fixes #21:

- adds option to specify debug mode in script
    - deletes and downloads fresh stacks-blockchain repo
    - uses `script` command to record terminal output to file 
    - runs `cargo start` with additional env vars
- updates readme for better flow of information and debug actions
- updates readme with new Youtube demo and more information