### PR TITLE
Fix errors due to mstx/ustx

### DIFF
--- a/config-miner-krypton.sh
+++ b/config-miner-krypton.sh
@@ -154,6 +154,11 @@ else
   # replace seed with privateKey from keychain
   sed -i "s/replace-with-your-private-key/$(jq -r '.keyInfo .privateKey' "$HOME"/keychain.json)/g" "$HOME"/krypton-miner-conf.toml
 fi
+if grep -q "ustx" krypton-miner-conf.toml; then 
+  # replace ustx with mstx in config file
+  printf '\e[1;31m%-6s\e[m\n' "SCRIPT: Changing ustx to mstx in config."
+  sed -i "s/ustx/mstx/g" "$HOME"/krypton-miner-conf.toml
+fi
 
 # check the test BTC balance before starting the miner
 # otherwise those UTXOs might not exist!

--- a/krypton-miner-conf.toml
+++ b/krypton-miner-conf.toml
@@ -5,6 +5,11 @@ bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d
 # Enter your private key here!
 seed = "replace-with-your-private-key"
 miner = true
+# uncomment to add a working directory
+# that saves chainstate info, but
+# may cause errors if data corrupted
+# default is /tmp/stacks-testnet-random
+# working_dir = /path/to/working/dir
 
 [burnchain]
 chain = "bitcoin"
@@ -12,16 +17,21 @@ mode = "krypton"
 peer_host = "bitcoind.krypton.blockstack.org"
 rpc_port = 18443
 peer_port = 18444
+# uncomment to change burn fee cap
+# burn_fee_cap = 20000
 
-[[ustx_balance]]
+# note this needs to be mstx NOT ustx
+# when using Krypton with tagged version
+# 24.0.0.0-xenon for the competition
+[[mstx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
 amount = 10000000000000000
-[[ustx_balance]]
+[[mstx_balance]]
 address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
 amount = 10000000000000000
-[[ustx_balance]]
+[[mstx_balance]]
 address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
 amount = 10000000000000000
-[[ustx_balance]]
+[[mstx_balance]]
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000


### PR DESCRIPTION
From @psq in Discord:
> good news, I think I figured out what was going on, and there is an easy fix
> when I replied that using ustx_balance vs. mstx_balance should not matter as long as it matches the code, I was assuming that the node would panic when reading the configuration file like it tends to do when anything is not right in that file if you did not use the expected keywords
> but what happens instead is that it just ignores any values with [[...]] it does not know about, so you end up starting the miner without these balances, which results in a different consensus calculation (what I was suspecting all along), and why some nodes where mining off a different fork, and sure enough looking at your log, that's exactly when the consensus started to diverge while creating the genesis block
> so, for either version 23, or 24.0, you must use the [[mstx_balance]] flavor

This PR includes an update to the configuration file as well as a check in the script that will update an existing config file to the correct format.