### PR TITLE
set correct dir before git pull

### DIFF
--- a/config-miner-krypton.sh
+++ b/config-miner-krypton.sh
@@ -103,6 +103,8 @@ if [ -d "$HOME/stacks-blockchain" ]; then
       # clone stacks-blockchain repo
       git clone -q https://github.com/blockstack/stacks-blockchain.git "$HOME"/stacks-blockchain
     else
+      # change to stacks-blockchain directory
+      cd "$HOME"/stacks-blockchain
       printf '\e[1;32m%-6s\e[m\n' "SCRIPT: stacks-blockchain directory detected. updating via git."
       git pull
   fi


### PR DESCRIPTION
Current version of the script will not run if stacks-blockchain is directed, this fixes it by changing the directory to stacks-blockchain before running git.

```
SCRIPT: NVM detected.
SCRIPT: Node.js detected, version: v14.12.0
SCRIPT: Rust detected, version: rustc 1.46.0 (04488afe3 2020-08-24)
SCRIPT: stacks-blockchain directory detected. updating via git.
fatal: not a git repository (or any of the parent directories): .git
```